### PR TITLE
Use es6-promise to support older environments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,11 @@ var _path = require('path');
 
 var _path2 = _interopRequireDefault(_path);
 
+var _es6Promise = require('es6-promise');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _es6Promise.polyfill)();
 
 /**
  * Globcmd

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "gulp-mocha": "^2.2.0"
   },
   "dependencies": {
+    "es6-promise": "^3.0.2",
     "glob": "^6.0.1",
     "minimist": "^1.2.0"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,8 @@
 import glob from 'glob';
 import path from 'path';
+import {polyfill} from 'es6-promise';
+
+polyfill();
 
 /**
  * Globcmd


### PR DESCRIPTION
I was looking at `cli-glob` for a work project, but noticed it uses `Promise`! Many of our projects are still on 0.10.x, which doesn't support `Promise` natively. It's a small change to support a broader set of environments.
